### PR TITLE
Add pcntl extension to php8.4 ci image

### DIFF
--- a/ci/Dockerfile.php8.4-nodejs22
+++ b/ci/Dockerfile.php8.4-nodejs22
@@ -28,6 +28,7 @@ RUN apt update \
       intl \
       opcache \
       pdo_mysql \
+      pcntl \
   && pecl install xdebug \
   && docker-php-ext-enable xdebug \
   && apt clean


### PR DESCRIPTION
Needed to run composer install for repos with laravel/horizon requirement.